### PR TITLE
BOM-1414: Dropped support for Django versions below 2.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,20 +7,20 @@
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via -r requirements/base.in, python-dotenv
+click==7.1.1              # via -r requirements/base.in, python-dotenv
 colorama==0.4.3           # via -r requirements/base.in
 dj-database-url==0.5.0    # via -r requirements/base.in
 django-bootstrap3==12.0.3  # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget  # via -r requirements/base.in
 django-dotenv==1.4.2      # via -r requirements/base.in
 django-filter==2.2.0      # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
-django==2.2.10            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework
+django-model-utils==4.0.0  # via -r requirements/base.in
+django==2.2.11            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.in
 idna==2.9                 # via requests
 lazy-object-proxy==1.4.0  # via -c requirements/constraints.txt, -r requirements/base.in
 ordereddict==1.1          # via -r requirements/base.in
-pygments==2.5.2           # via -r requirements/base.in
+pygments==2.6.1           # via -r requirements/base.in
 python-dateutil==2.8.1    # via -r requirements/base.in
 python-dotenv==0.6.0      # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2019.3              # via -r requirements/base.in, django, django-datetime-widget

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,9 +10,6 @@
 
 boto==2.39.0
 
-# Version 4.0.0 dropped support for Django < 2.0.1
-django-model-utils<4.0.0
-
 # above this versions are giving error.
 python-dotenv==0.6.0
 

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.10            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework
+django==2.2.11            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -9,17 +9,17 @@ attrs==19.3.0             # via pytest
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via -r requirements/base.in, python-dotenv
+click==7.1.1              # via -r requirements/base.in, python-dotenv
 colorama==0.4.3           # via -r requirements/base.in
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 dj-database-url==0.5.0    # via -r requirements/base.in
 django-bootstrap3==12.0.3  # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget  # via -r requirements/base.in
 django-dotenv==1.4.2      # via -r requirements/base.in
 django-filter==2.2.0      # via -r requirements/base.in
 django-jenkins==0.110.0   # via -r requirements/jenkins.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
-django==2.2.10            # via -r requirements/base.in, django-datetime-widget, django-filter, django-jenkins, django-model-utils, djangorestframework, model-mommy
+django-model-utils==4.0.0  # via -r requirements/base.in
+django==2.2.11            # via -r requirements/base.in, django-datetime-widget, django-filter, django-jenkins, django-model-utils, djangorestframework, model-mommy
 djangorestframework==3.11.0  # via -r requirements/base.in
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via requests
@@ -31,17 +31,17 @@ mock==3.0.5               # via -r requirements/testing.in
 model-mommy==2.0.0        # via -r requirements/testing.in
 more-itertools==8.2.0     # via pytest
 ordereddict==1.1          # via -r requirements/base.in
-packaging==20.1           # via pytest
+packaging==20.3           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 psycopg2==2.8.4           # via -r requirements/production.in
 py==1.8.1                 # via pytest
-pygments==2.5.2           # via -r requirements/base.in
+pygments==2.6.1           # via -r requirements/base.in
 pylint==2.4.4             # via -r requirements/testing.in
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/testing.in
 pytest-django==3.8.0      # via -r requirements/testing.in
-pytest==5.3.5             # via -r requirements/testing.in, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/testing.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.in
 python-dotenv==0.6.0      # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2019.3              # via -r requirements/base.in, django, django-datetime-widget

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
+click==7.1.1              # via pip-tools
 pip-tools==4.5.1          # via -r requirements/pip_tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,22 +7,22 @@
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via -r requirements/base.in, python-dotenv
+click==7.1.1              # via -r requirements/base.in, python-dotenv
 colorama==0.4.3           # via -r requirements/base.in
 dj-database-url==0.5.0    # via -r requirements/base.in
 django-bootstrap3==12.0.3  # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget  # via -r requirements/base.in
 django-dotenv==1.4.2      # via -r requirements/base.in
 django-filter==2.2.0      # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
-django==2.2.10            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework
+django-model-utils==4.0.0  # via -r requirements/base.in
+django==2.2.11            # via -r requirements/base.in, django-datetime-widget, django-filter, django-model-utils, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.in
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via requests
 lazy-object-proxy==1.4.0  # via -c requirements/constraints.txt, -r requirements/base.in
 ordereddict==1.1          # via -r requirements/base.in
 psycopg2==2.8.4           # via -r requirements/production.in
-pygments==2.5.2           # via -r requirements/base.in
+pygments==2.6.1           # via -r requirements/base.in
 python-dateutil==2.8.1    # via -r requirements/base.in
 python-dotenv==0.6.0      # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2019.3              # via -r requirements/base.in, django, django-datetime-widget

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -9,15 +9,15 @@ attrs==19.3.0             # via pytest
 boto==2.39.0              # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via -r requirements/base.in, python-dotenv
+click==7.1.1              # via -r requirements/base.in, python-dotenv
 colorama==0.4.3           # via -r requirements/base.in
-coverage==5.0.3           # via pytest-cov
+coverage==5.0.4           # via pytest-cov
 dj-database-url==0.5.0    # via -r requirements/base.in
 django-bootstrap3==12.0.3  # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget  # via -r requirements/base.in
 django-dotenv==1.4.2      # via -r requirements/base.in
 django-filter==2.2.0      # via -r requirements/base.in
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
+django-model-utils==4.0.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via requests
@@ -29,17 +29,17 @@ mock==3.0.5               # via -r requirements/testing.in
 model-mommy==2.0.0        # via -r requirements/testing.in
 more-itertools==8.2.0     # via pytest
 ordereddict==1.1          # via -r requirements/base.in
-packaging==20.1           # via pytest
+packaging==20.3           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 psycopg2==2.8.4           # via -r requirements/production.in
 py==1.8.1                 # via pytest
-pygments==2.5.2           # via -r requirements/base.in
+pygments==2.6.1           # via -r requirements/base.in
 pylint==2.4.4             # via -r requirements/testing.in
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/testing.in
 pytest-django==3.8.0      # via -r requirements/testing.in
-pytest==5.3.5             # via -r requirements/testing.in, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/testing.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.in
 python-dotenv==0.6.0      # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2019.3              # via -r requirements/base.in, django, django-datetime-widget

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,8 +8,8 @@ appdirs==1.4.3            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.2.0  # via virtualenv
-packaging==20.1           # via tox
+importlib-resources==1.4.0  # via virtualenv
+packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
@@ -17,5 +17,5 @@ six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.5               # via -r requirements/travis.in, tox-battery
-virtualenv==20.0.7        # via tox
+virtualenv==20.0.13       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = {py35}-django{111,20,21,22}
+envlist = {py35}-django22
 skipsdist = true
 
 [testenv]
 passenv = DJANGO_SETTINGS_MODULE
 deps =
-    django22: Django>=2.2,<2.3
+    django22: -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/testing.txt
 whitelist_externals:
     make


### PR DESCRIPTION
JIRA: [BOM-1414](https://openedx.atlassian.net/browse/BOM-1414)

- Dropped support for Django versions below 2.2
- Removed pin from django-model-utils