### PR TITLE
chore: Fixing github actions with allow-failure for django32.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   run_tests:
     name: Tests
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,7 +45,6 @@ jobs:
     - name: Install tox
       run:  pip install tox
     - name: Run Tests
-      continue-on-error: true
       env:
           TOXENV: ${{ matrix.toxenv }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   run_tests:
     name: Tests
-    continue-on-error: true
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +49,7 @@ jobs:
     - name: Install tox
       run:  pip install tox
     - name: Run Tests
+      continue-on-error: ${{ matrix.allow-failure }}
       env:
           TOXENV: ${{ matrix.toxenv }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-20.04
         python-version: ['3.8']
-        toxenv: ['django22', 'django30', 'django31']
+        toxenv: ['django22', 'django30', 'django31', 'django32']
     services:
       postgres:
         image: postgres:10.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,12 @@ jobs:
           - ubuntu-20.04
         python-version:
           - 3.8
-        toxenv:
-          - django22
-          - django30
-          - django31
-          - django32
+        django-version: ['django22', 'django30', 'django31']
+        allow-failure: [ false ]
+        include:
+          - python-version: 3.8
+            toxenv: django32
+            allow-failure: true
     services:
       postgres:
         image: postgres:10.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
         toxenv: ['django22', 'django30', 'django31']
         allow-failure: [ false ]
         include:
-          - python-version: 3.8
+          - runs-on: ubuntu-latest
+            python-version: 3.8
             toxenv: django32
             allow-failure: true
     services:
@@ -49,7 +50,7 @@ jobs:
     - name: Install tox
       run:  pip install tox
     - name: Run Tests
-      continue-on-error: ${{ matrix.allow-failure }}
+      continue-on-error: true
       env:
           TOXENV: ${{ matrix.toxenv }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-        python-version:
-          - 3.8
-        django-version: ['django22', 'django30', 'django31']
+        python-version: ['3.8']
+        toxenv: ['django22', 'django30', 'django31']
         allow-failure: [ false ]
         include:
           - python-version: 3.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,6 @@ jobs:
           - ubuntu-20.04
         python-version: ['3.8']
         toxenv: ['django22', 'django30', 'django31']
-        allow-failure: [ false ]
-        include:
-          - runs-on: ubuntu-latest
-            python-version: 3.8
-            toxenv: django32
-            allow-failure: true
     services:
       postgres:
         image: postgres:10.8


### PR DESCRIPTION
chore: Fixing github actions with allow-failure for django32.

Build is failing with django32.