### PR TITLE
refactor: Removed the django32 condition.

### DIFF
--- a/openedxstats/apps/sites/apps.py
+++ b/openedxstats/apps/sites/apps.py
@@ -1,8 +1,6 @@
-import django
 from django.apps import AppConfig
 
 
 class SitesConfig(AppConfig):
     name = 'sites'
-    if django.VERSION >= (3, 2):
-        default = False
+    default = False

--- a/openedxstats/apps/slackdata/apps.py
+++ b/openedxstats/apps/slackdata/apps.py
@@ -1,8 +1,6 @@
-import django
 from django.apps import AppConfig
 
 
 class SlackdataConfig(AppConfig):
     name = 'slackdata'
-    if django.VERSION >= (3, 2):
-        default = False
+    default = False


### PR DESCRIPTION
refactor: Removed the django32 condition.

https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.default

prevent Django from selecting a configuration class automatically.
it already has defined path in Installed apps.

Django [PR](https://github.com/django/django/commit/3f2821af6bc48fa8e7970c1ce27bc54c3172545e#diff-0f8bc657bc27c9f80385c4814c2c2ebc033bda3e03285a7212965309a481cc70R104)
