### PR TITLE
feat: load staticfiles are deprecated 

### DIFF
--- a/openedxstats/apps/sites/templates/sites/ot_chart.html
+++ b/openedxstats/apps/sites/templates/sites/ot_chart.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{%  load staticfiles %}
+{%  load static %}
 {% block bootstrap3_extra_head %}
     <link rel="shortcut icon" href="{%  static 'sites/favicon.ico' %}">
     <script type="text/javascript" language="javascript" src="{% static 'sites/jquery.flot.js' %}"></script>

--- a/openedxstats/apps/sites/templates/sites/site_detail.html
+++ b/openedxstats/apps/sites/templates/sites/site_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{%  load staticfiles %}
+{%  load static %}
 {% block bootstrap3_extra_head %}
     <link rel="shortcut icon" href="{%  static 'sites/favicon.ico' %}">
     <script>


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.0/releases/2.1/#features-deprecated-in-2-1

feat: {% load staticfiles %} are deprecated in favor of {% load static %} which works the same.