### PR TITLE
build: Download the common constraint locally.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Packages required in a production environment
 -c constraints.txt
 
-Django >= 1.11, <2.3
+Django
 boto
 click
 colorama

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.2
+charset-normalizer==2.0.3
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -18,7 +18,7 @@ dj-database-url==0.5.0
     # via -r requirements/base.in
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-bootstrap3
     #   django-datetime-widget
@@ -47,7 +47,7 @@ pygments==2.9.0
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
-python-dotenv==0.18.0
+python-dotenv==0.19.0
     # via -r requirements/base.in
 pytz==2021.1
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,22 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django versiongit
+
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,10 @@
 # linking to it here is good.
 
 # Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
- 
+
+-c common_constraints.txt
+
+Django<2.3
+
 # astroid 2.3.3 has requirement wrapt==1.11 thats why pinned it here.
 wrapt==1.11

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.6.2
+astroid==2.6.5
     # via pylint
 attrs==21.2.0
     # via pytest
@@ -12,7 +12,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.2
+charset-normalizer==2.0.3
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -24,7 +24,7 @@ dj-database-url==0.5.0
     # via -r requirements/base.in
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-bootstrap3
     #   django-datetime-widget
@@ -77,7 +77,7 @@ py==1.10.0
     # via pytest
 pygments==2.9.0
     # via -r requirements/base.in
-pylint==2.9.3
+pylint==2.9.5
     # via -r requirements/testing.in
 pyparsing==2.4.7
     # via packaging
@@ -92,7 +92,7 @@ pytest-django==4.4.0
     # via -r requirements/testing.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
-python-dotenv==0.18.0
+python-dotenv==0.19.0
     # via -r requirements/base.in
 pytz==2021.1
     # via
@@ -120,7 +120,7 @@ urllib3==1.26.6
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in
-whitenoise==5.2.0
+whitenoise==5.3.0
     # via -r requirements/production.in
 wrapt==1.11.0
     # via

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,11 +6,11 @@
 #
 click==8.0.1
     # via pip-tools
-pep517==0.10.0
+pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip_tools.in
-toml==0.10.2
+tomli==1.1.0
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,7 +8,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.2
+charset-normalizer==2.0.3
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -18,7 +18,7 @@ dj-database-url==0.5.0
     # via -r requirements/base.in
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-bootstrap3
     #   django-datetime-widget
@@ -51,7 +51,7 @@ pygments==2.9.0
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
-python-dotenv==0.18.0
+python-dotenv==0.19.0
     # via -r requirements/base.in
 pytz==2021.1
     # via
@@ -74,7 +74,7 @@ urllib3==1.26.6
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in
-whitenoise==5.2.0
+whitenoise==5.3.0
     # via -r requirements/production.in
 wrapt==1.11
     # via

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.6.2
+astroid==2.6.5
     # via pylint
 attrs==21.2.0
     # via pytest
@@ -12,7 +12,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.2
+charset-normalizer==2.0.3
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -23,7 +23,7 @@ coverage==5.5
 dj-database-url==0.5.0
     # via -r requirements/base.in
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-bootstrap3
     #   django-datetime-widget
@@ -73,7 +73,7 @@ py==1.10.0
     # via pytest
 pygments==2.9.0
     # via -r requirements/base.in
-pylint==2.9.3
+pylint==2.9.5
     # via -r requirements/testing.in
 pyparsing==2.4.7
     # via packaging
@@ -88,7 +88,7 @@ pytest-django==4.4.0
     # via -r requirements/testing.in
 python-dateutil==2.8.2
     # via -r requirements/base.in
-python-dotenv==0.18.0
+python-dotenv==0.19.0
     # via -r requirements/base.in
 pytz==2021.1
     # via
@@ -116,7 +116,7 @@ urllib3==1.26.6
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in
-whitenoise==5.2.0
+whitenoise==5.3.0
     # via -r requirements/production.in
 wrapt==1.11.0
     # via

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,7 +14,7 @@ filelock==3.0.12
     #   virtualenv
 packaging==21.0
     # via tox
-platformdirs==2.0.2
+platformdirs==2.1.0
     # via virtualenv
 pluggy==0.13.1
     # via tox


### PR DESCRIPTION
**Approach Implemented**
pip-tools gives error if two different django versions appeared in different files. pip-tools gives priority to the top pin which is  `common constraint django<2.3` and on finding another version `django>2.3` it gives conflicting issues.

Downloaded the common constraint locally and remove the django-version from that file before `make upgrade`.
Fixed this issue by removing the top pin.

**2nd Approach** 
1. Check all services and verify that have django<2.3 if not add it.
2. Remove django from common constraint URL.
3. For packages its not a big concern will catch in make upgrades prs.