### PR TITLE
Replace django-dotenv with django-environ-2

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,13 +2,13 @@
 import os
 import sys
 
-from dotenv import load_dotenv
+import environ
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openedxstats.settings")
 
-    dotenv_path = os.path.join(os.path.dirname(__file__), 'openedxstats/.env')
-    load_dotenv(dotenv_path)
+    env_file_path = os.path.join(os.path.dirname(__file__), 'openedxstats/.env')
+    environ.Env.read_env(env_file_path)
 
     from django.core.management import execute_from_command_line
 

--- a/openedxstats/wsgi.py
+++ b/openedxstats/wsgi.py
@@ -8,13 +8,13 @@ import os
 from os.path import abspath, dirname, join
 from sys import path
 
-import dotenv
+import environ
 
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 
-dotenv_path = join(dirname(__file__), '.env')
-dotenv.load_dotenv(dotenv_path)
+env_file_path = join(dirname(__file__), '.env')
+environ.Env.read_env(env_file_path)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openedxstats.settings")
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,7 +8,7 @@ colorama
 dj-database-url
 Django
 django-bootstrap3
-django-dotenv
+django-environ-2
 django-filter
 django-model-utils
 djangorestframework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
     # via -r requirements/base.in
-django-dotenv==1.4.2
+django-environ-2==2.1.0
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -36,7 +36,7 @@ django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
     # via -r requirements/base.in
-django-dotenv==1.4.2
+django-environ-2==2.1.0
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -29,7 +29,7 @@ django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
     # via -r requirements/base.in
-django-dotenv==1.4.2
+django-environ-2==2.1.0
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -34,7 +34,7 @@ django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
     # via -r requirements/base.in
-django-dotenv==1.4.2
+django-environ-2==2.1.0
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in


### PR DESCRIPTION
## Description

This PR replaces `django-dotenv` with `django-environ-2` package.

This PR is a part of Django 3.2 upgrade initiative. https://github.com/edx/upgrades/issues/22

## Test instruction

1. Pull this PR
2. Run `make tests`, make sure all tests passes.