### PR TITLE
Remove dependency on model-mommy and upgrade remaining dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -43,7 +43,7 @@ lazy-object-proxy==1.6.0
     # via -r requirements/base.in
 ordereddict==1.1
     # via -r requirements/base.in
-pygments==2.9.0
+pygments==2.10.0
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -12,11 +12,32 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 
-# using LTS django versiongit
+# using LTS django version
 
 
 # latest version is causing e2e failures in edx-platform.
+# See pyjwt[crypto]<2.0.0 comment.
 drf-jwt<1.19.1
 
-# Newer versions causing tests failures in multiple repos.
-pyjwt[crypto]==1.7.1
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-auth-backends<4.0.0
+
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-drf-extensions<7.0.0
+
+# PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
+# actively working to fix. A number of the active constraints are all related
+# to this effort. Additionally, your IDA/service may also be affected directly
+# by these changes. You should not upgrade without knowing what you are doing.
+pyjwt[crypto]<2.0.0
+
+# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
+social-auth-app-django<5.0.0
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
+# See pyjwt[crypto]<2.0.0 comment.
+social-auth-core<4.0.3
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.6.5
+astroid==2.7.2
     # via pylint
 attrs==21.2.0
     # via pytest
@@ -12,7 +12,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -32,7 +32,6 @@ django==2.2.24
     #   django-jenkins
     #   django-model-utils
     #   djangorestframework
-    #   model-mommy
 django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
@@ -53,7 +52,7 @@ idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
-isort==5.9.2
+isort==5.9.3
     # via pylint
 lazy-object-proxy==1.6.0
     # via
@@ -63,21 +62,21 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/testing.in
-model-mommy==2.0.0
-    # via -r requirements/testing.in
 ordereddict==1.1
     # via -r requirements/base.in
 packaging==21.0
     # via pytest
+platformdirs==2.2.0
+    # via pylint
 pluggy==0.13.1
     # via pytest
 psycopg2==2.9.1
     # via -r requirements/production.in
 py==1.10.0
     # via pytest
-pygments==2.9.0
+pygments==2.10.0
     # via -r requirements/base.in
-pylint==2.9.5
+pylint==2.10.2
     # via -r requirements/testing.in
 pyparsing==2.4.7
     # via packaging

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,9 +10,9 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip_tools.in
-tomli==1.1.0
+tomli==1.2.1
     # via pep517
-wheel==0.36.2
+wheel==0.37.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,7 +8,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -47,7 +47,7 @@ ordereddict==1.1
     # via -r requirements/base.in
 psycopg2==2.9.1
     # via -r requirements/production.in
-pygments==2.9.0
+pygments==2.10.0
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via -r requirements/base.in

--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -4,7 +4,6 @@
 -r production.in
 
 mock
-model-mommy
 pylint
 pytest
 pytest-cov

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.6.5
+astroid==2.7.2
     # via pylint
 attrs==21.2.0
     # via pytest
@@ -12,7 +12,7 @@ boto==2.49.0
     # via -r requirements/base.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==8.0.1
     # via -r requirements/base.in
@@ -30,7 +30,6 @@ dj-database-url==0.5.0
     #   django-filter
     #   django-model-utils
     #   djangorestframework
-    #   model-mommy
 django-bootstrap3==15.0.0
     # via -r requirements/base.in
 git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
@@ -49,7 +48,7 @@ idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
-isort==5.9.2
+isort==5.9.3
     # via pylint
 lazy-object-proxy==1.6.0
     # via
@@ -59,21 +58,21 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/testing.in
-model-mommy==2.0.0
-    # via -r requirements/testing.in
 ordereddict==1.1
     # via -r requirements/base.in
 packaging==21.0
     # via pytest
+platformdirs==2.2.0
+    # via pylint
 pluggy==0.13.1
     # via pytest
 psycopg2==2.9.1
     # via -r requirements/production.in
 py==1.10.0
     # via pytest
-pygments==2.9.0
+pygments==2.10.0
     # via -r requirements/base.in
-pylint==2.9.5
+pylint==2.10.2
     # via -r requirements/testing.in
 pyparsing==2.4.7
     # via packaging

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,7 +14,7 @@ filelock==3.0.12
     #   virtualenv
 packaging==21.0
     # via tox
-platformdirs==2.1.0
+platformdirs==2.2.0
     # via virtualenv
 pluggy==0.13.1
     # via tox
@@ -28,11 +28,11 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.0
+tox==3.24.3
     # via
     #   -r requirements/travis.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/travis.in
-virtualenv==20.6.0
+virtualenv==20.7.2
     # via tox


### PR DESCRIPTION
## Summary

This PR removes a dependency on the [deprecated model-mommy package](https://github.com/berinhard/model_mommy) in support of the EdX Django 3.2 upgrade (associated Github issue [here](https://github.com/edx/upgrades/issues/31)). As far as I can tell, this dependency is unused in this repository, so I opted to remove it rather than replacing it with the [model-bakery](https://model-bakery.readthedocs.io/en/latest/index.html) package.

## How I Got Here

I first cloned and set up the repository by using the instructions in the README. I then installed the test requirements by running `make install-test`. I then ran `make tests` to run the tests.

I grepped the entire repository to find any mentions of `model_mommy` and was unable to find any. I also looked at the two test files in `openedxstats/apps/` and the `import_sites` management command to see how test data was getting created. As far as I can tell, this dependency wasn't actually used anywhere.

I deleted the relevant line in `requirements/testing.in` and ran `make upgrade` to create new requirements files. I then re-ran `make install-test` and `make tests` to verify that the tests ran correctly. They did, so I concluded that this dependency was in fact not needed.