### PR TITLE
BOM-2782: Use DeploymentMonitoringMiddleware in settings

### DIFF
--- a/openedxstats/settings/base.py
+++ b/openedxstats/settings/base.py
@@ -54,6 +54,7 @@ PROJECT_APPS = []
 INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE = [
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ django-environ-2
 django-filter
 django-model-utils
 djangorestframework
+edx-django-utils
 lazy-object-proxy
 ordereddict
 Pygments

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,30 +22,44 @@ django==3.2.7
     # via
     #   -r requirements/base.in
     #   django-bootstrap3
+    #   django-crum
     #   django-datetime-widget
     #   django-filter
     #   django-model-utils
     #   djangorestframework
+    #   edx-django-utils
 django-bootstrap3==15.0.0
     # via -r requirements/base.in
-git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
+django-crum==0.7.9
+    # via edx-django-utils
+django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
 django-environ==0.7.0
     # via django-environ-2
 django-environ-2==2.3.0
     # via -r requirements/base.in
-django-filter==2.4.0
+django-filter==21.1
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via -r requirements/base.in
+django-waffle==2.2.1
+    # via edx-django-utils
 djangorestframework==3.12.4
+    # via -r requirements/base.in
+edx-django-utils==4.4.0
     # via -r requirements/base.in
 idna==3.2
     # via requests
 lazy-object-proxy==1.6.0
     # via -r requirements/base.in
+newrelic==7.0.0.166
+    # via edx-django-utils
 ordereddict==1.1
     # via -r requirements/base.in
+pbr==5.6.0
+    # via stevedore
+psutil==5.8.0
+    # via edx-django-utils
 pygments==2.10.0
     # via -r requirements/base.in
 python-dateutil==2.8.2
@@ -69,7 +83,9 @@ slacker==0.14.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
-urllib3==1.26.6
+stevedore==3.4.0
+    # via edx-django-utils
+urllib3==1.26.7
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -19,25 +19,6 @@
 # See pyjwt[crypto]<2.0.0 comment.
 drf-jwt<1.19.1
 
-# 4.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
-edx-auth-backends<4.0.0
-
-# 7.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
-edx-drf-extensions<7.0.0
-
-# PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
-# actively working to fix. A number of the active constraints are all related
-# to this effort. Additionally, your IDA/service may also be affected directly
-# by these changes. You should not upgrade without knowing what you are doing.
-pyjwt[crypto]<2.0.0
-
-# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
-social-auth-app-django<5.0.0
-
-# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
-# See pyjwt[crypto]<2.0.0 comment.
-social-auth-core<4.0.3
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,23 +22,31 @@ django==3.2.7
     # via
     #   -r requirements/base.in
     #   django-bootstrap3
+    #   django-crum
     #   django-datetime-widget
     #   django-filter
     #   django-model-utils
     #   djangorestframework
+    #   edx-django-utils
 django-bootstrap3==15.0.0
     # via -r requirements/base.in
-git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
+django-crum==0.7.9
+    # via edx-django-utils
+django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
 django-environ==0.7.0
     # via django-environ-2
 django-environ-2==2.3.0
     # via -r requirements/base.in
-django-filter==2.4.0
+django-filter==21.1
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via -r requirements/base.in
+django-waffle==2.2.1
+    # via edx-django-utils
 djangorestframework==3.12.4
+    # via -r requirements/base.in
+edx-django-utils==4.4.0
     # via -r requirements/base.in
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -46,8 +54,14 @@ idna==3.2
     # via requests
 lazy-object-proxy==1.6.0
     # via -r requirements/base.in
+newrelic==7.0.0.166
+    # via edx-django-utils
 ordereddict==1.1
     # via -r requirements/base.in
+pbr==5.6.0
+    # via stevedore
+psutil==5.8.0
+    # via edx-django-utils
 psycopg2==2.9.1
     # via -r requirements/production.in
 pygments==2.10.0
@@ -73,7 +87,9 @@ slacker==0.14.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
-urllib3==1.26.6
+stevedore==3.4.0
+    # via edx-django-utils
+urllib3==1.26.7
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -27,23 +27,31 @@ dj-database-url==0.5.0
     # via
     #   -r requirements/base.in
     #   django-bootstrap3
+    #   django-crum
     #   django-datetime-widget
     #   django-filter
     #   django-model-utils
     #   djangorestframework
+    #   edx-django-utils
 django-bootstrap3==15.0.0
     # via -r requirements/base.in
-git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986#egg=django-datetime-widget
+django-crum==0.7.9
+    # via edx-django-utils
+django-datetime-widget @ git+https://github.com/behype-inc/django-datetime-widget.git@2a123692cf18614a60363cb1828dd29cec9ed986
     # via -r requirements/base.in
 django-environ==0.7.0
     # via django-environ-2
 django-environ-2==2.3.0
     # via -r requirements/base.in
-django-filter==2.4.0
+django-filter==21.1
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via -r requirements/base.in
+django-waffle==2.2.1
+    # via edx-django-utils
 djangorestframework==3.12.4
+    # via -r requirements/base.in
+edx-django-utils==4.4.0
     # via -r requirements/base.in
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -61,14 +69,20 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/testing.in
+newrelic==7.0.0.166
+    # via edx-django-utils
 ordereddict==1.1
     # via -r requirements/base.in
 packaging==21.0
     # via pytest
-platformdirs==2.3.0
+pbr==5.6.0
+    # via stevedore
+platformdirs==2.4.0
     # via pylint
 pluggy==1.0.0
     # via pytest
+psutil==5.8.0
+    # via edx-django-utils
 psycopg2==2.9.1
     # via -r requirements/production.in
 py==1.10.0
@@ -109,6 +123,8 @@ slacker==0.14.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
+stevedore==3.4.0
+    # via edx-django-utils
 toml==0.10.2
     # via
     #   pylint
@@ -118,7 +134,7 @@ typing-extensions==3.10.0.2
     # via
     #   astroid
     #   pylint
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
 urwid==2.1.2
     # via -r requirements/base.in


### PR DESCRIPTION
**Issue:** [BOM-2782](https://openedx.atlassian.net/browse/BOM-2782)

### Description
- Added the `DeploymentMonitroringMiddleware` to record `Django` and `Python` versions in the `NewRelic`.
